### PR TITLE
fixed: pending_username not found from frontend when signup, 2FA done

### DIFF
--- a/srcs/requirements/user_management/project/account/templates/signup.html
+++ b/srcs/requirements/user_management/project/account/templates/signup.html
@@ -131,11 +131,17 @@
     function verifyCode(context) {
         var email = $("#signupEmail").val();
         var verificationCode = $("#verificationCode").val();
+        var username = $("#signupForm input[name='username']").val();
+        console.log('Username:', username);
 
         $.ajax({
             url: '{% url "account:verify_one_time_code" %}',
             type: 'POST',
-            data: { 'email': email, 'one_time_code': verificationCode, 'context': context },
+            data: {
+                'email': email,
+                'one_time_code': verificationCode,
+                'context': context,
+                'pending_username': username },
             headers: { "X-CSRFToken": getCookie('csrftoken') },
             success: function (data) {
                 if (data.success) {

--- a/srcs/requirements/user_management/project/account/views.py
+++ b/srcs/requirements/user_management/project/account/views.py
@@ -108,12 +108,13 @@ def verify_one_time_code(request):
     if request.method == 'POST':
         csrf_token = get_token(request)
         print("\n\nCSRF Token from request:", request.headers.get('X-CSRFToken'))
-        submitted_code = request.POST.get('one_time_code')
-        stored_code = request.session.get('one_time_code')
+        submitted_code = request.POST.get('one_time_code').strip()
+        stored_code = request.session.get('one_time_code').strip()
         context = request.POST.get('context')
         print("\n\ncode from Session : ", stored_code)
         print("code from User : ", submitted_code, '\n\n')
-        pending_username = request.session.get('pending_username')
+        pending_username = request.session.get('pending_username') or request.POST.get('pending_username')
+        print("pending_username : ", pending_username, '\n\n')
         if pending_username:
             user = User.objects.get(username=pending_username)
             if submitted_code == stored_code:


### PR DESCRIPTION
fixed error status 400 with 'User authentication not found' because of missing 'pending_username':

now getting 'pending_username' either from session(called by views.api_login_view) or ajax data(called by signup.html)