### PR TITLE
125 jwttoken expiration check

### DIFF
--- a/srcs/requirements/user_management/project/account/templates/home.html
+++ b/srcs/requirements/user_management/project/account/templates/home.html
@@ -84,9 +84,13 @@
         headers: {
           'Authorization': accessToken
         },
-        success: function(data) {
+        success: function(data, textStatus, xhr) {
           console.log('Check refresh successful:', data);
-          // Handle successful response
+          var new_accessToken = xhr.getResponseHeader('Authorization');
+          if (new_accessToken) {
+            sessionStorage.setItem('accessToken', new_accessToken);
+            console.log('Update accessToken on Storage');
+          }
         },
         error: function(xhr, textStatus, errorThrown) {
           console.error('Error checking refresh:', errorThrown);

--- a/srcs/requirements/user_management/project/account/templates/home.html
+++ b/srcs/requirements/user_management/project/account/templates/home.html
@@ -66,7 +66,7 @@
 </form>
 <a href="{% url 'account:friend' %}">Friends</a>
 <a href="{% url 'account:detail' %}">Detail</a>
-
+<button id="tokenTestButton">TokenTest</button>
 {% else %}
 
 <a href="#" id="loginLink">Log in</a>
@@ -75,18 +75,41 @@
 
 <script>
   $(document).ready(function () {
-      $('#devDbButton').on('click', function () {
-          $.ajax({
-              type: 'GET',
-              url: '{% url "account:print_db" %}',
-              success: function (data) {
-                  console.log('Print all user data successful:', data);
-                  window.location.href = '{% url "account:print_db" %}';
-              },
-              error: function (error) {
-                  console.error('Error Cannot print user data:', error);
-              }
-          });
+    $('#tokenTestButton').on('click', function() {
+    var accessToken = sessionStorage.getItem('accessToken');
+    if (accessToken) {
+      $.ajax({
+        type: 'GET',
+        url: '{% url "account:check_refresh" %}',
+        headers: {
+          'Authorization': accessToken
+        },
+        success: function(data) {
+          console.log('Check refresh successful:', data);
+          // Handle successful response
+        },
+        error: function(xhr, textStatus, errorThrown) {
+          console.error('Error checking refresh:', errorThrown);
+          // Handle error
+        }
       });
+    } else {
+      console.error('Access token not found in sessionStorage');
+      // Handle case where access token is not found
+    }
   });
+    $('#devDbButton').on('click', function () {
+        $.ajax({
+            type: 'GET',
+            url: '{% url "account:print_db" %}',
+            success: function (data) {
+                console.log('Print all user data successful:', data);
+                window.location.href = '{% url "account:print_db" %}';
+            },
+            error: function (error) {
+                console.error('Error Cannot print user data:', error);
+            }
+        });
+    });
+});
 </script>

--- a/srcs/requirements/user_management/project/account/templates/login.html
+++ b/srcs/requirements/user_management/project/account/templates/login.html
@@ -91,8 +91,15 @@
       type: 'POST',
       data: $('#loginForm').serialize(),
       headers: { "X-CSRFToken": "{{ csrf_token }}" },
-      success: function (data) {
+      success: function (data, textStatus, xhr) {
         console.log('Login successful:', data);
+        // Extract access token from Authorization header
+        var accessToken = xhr.getResponseHeader('Authorization');
+        if (accessToken) {
+          // Store the access token in memory
+          sessionStorage.setItem('accessToken', accessToken);
+          console.log('Access token stored:', accessToken);
+        }
         if (data.requires_2fa) {
         // closeLoginPopup();
         // window.location.href = '';

--- a/srcs/requirements/user_management/project/account/templates/signup.html
+++ b/srcs/requirements/user_management/project/account/templates/signup.html
@@ -196,13 +196,18 @@
             type: 'POST',
             data: $('#signupForm').serialize(),
             headers: { "X-CSRFToken": getCookie('csrftoken') },
-            success: function (data) {
+            success: function (data, textStatus, xhr) {
                 if (data.success) {
                     console.log('signed up success\n\n');
                     closeSignupPopup();
                     closeLoginPopup();
+                    var accessToken = xhr.getResponseHeader('Authorization');
+                    if (accessToken) {
+                        // Store the access token in memory
+                        sessionStorage.setItem('accessToken', accessToken);
+                        console.log('Access token stored:', accessToken);
+                    }
                     window.location.href = '';
-
                 } else {
                     $('#signupPopupError').text(data.error);
                 }

--- a/srcs/requirements/user_management/project/account/urls.py
+++ b/srcs/requirements/user_management/project/account/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     path('access_code', views.send_one_time_code, name='send_one_time_code'),
     path('delete_account', views.delete_account, name='delete_account'),
     path('developer_setting', views.print_all_user_data, name='print_db'),
-    path('checkLogin', views.user_is_logged_in, name='user_is_logged_in'),
+    path('check_refresh', views.check_refresh, name='check_refresh'),
 
 ]
 

--- a/srcs/requirements/user_management/project/account/views.py
+++ b/srcs/requirements/user_management/project/account/views.py
@@ -157,9 +157,7 @@ def api_login_view(request):
             try:
                 print("original ACCESS TOKEN: ", str(access_token))
                 decodedToken = jwt.decode(str(access_token), secret_key, algorithms=["HS256"])
-                
-                request.session['access_token'] = str(access_token)
-                print("jwt on session: ", request.session['access_token'])
+
 
                 print("decode ACCESS TOKEN: ", decodedToken)
                 local_tz = pytz.timezone('Europe/Paris')

--- a/srcs/requirements/user_management/project/account/views.py
+++ b/srcs/requirements/user_management/project/account/views.py
@@ -88,8 +88,11 @@ def check_refresh(request):
         try:
             decoded_refresh_token = jwt.decode(refreshToken, settings.SECRET_KEY, algorithms=["HS256"])
             print("DECODED REFRESHTOKEN: ", decoded_refresh_token)
+            uid = decoded_refresh_token['user_id']
+            user = User.objects.get(pk=uid)
             refresh = RefreshToken(refreshToken)
             access = refresh.access_token
+            access['username'] = user.username
             new_accessToken = str(access)
 
             # Set new access token in response header
@@ -99,7 +102,6 @@ def check_refresh(request):
         # return JsonResponse({'error': 'Access token has expired'}, status=401)
         except jwt.ExpiredSignatureError:
             return JsonResponse({'error': 'Access/Refresh token has expired'}, status=401)
-
 
     except jwt.InvalidTokenError:
         print("Invalid token")

--- a/srcs/requirements/user_management/project/project/settings.py
+++ b/srcs/requirements/user_management/project/project/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 from pathlib import Path
 import os
 from datetime import timedelta
+import datetime
+
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -77,12 +79,21 @@ REST_FRAMWORK = {
 	)
 }
 
-SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(days=500),
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
-    'ROTATE_REFRESH_TOKENS': False,
-    'BLACKLIST_AFTER_ROTATION': True,
-}
+JWT_EXPIRATION_DELTA = datetime.timedelta(minutes=15)
+JWT_REFRESH_EXPIRATION_DELTA = datetime.timedelta(days=14)
+# Store access token in a cookie
+# JWT_AUTH_COOKIE = True
+# Mark cookie containing access token as secure
+# JWT_COOKIE_SECURE = True
+# JWT_COOKIE_SAMESITE = 'Lax'
+# JWT_ALGORITHM = 'RS256'
+# JWT_AUTH_HEADER_PREFIX = 'Token'
+JWT_ROTATE_REFRESH_TOKENS = True
+JWT_BLACKLIST_AFTER_ROTATION = True
+
+# session cookie lifetime set as an hour
+SESSION_COOKIE_AGE = 3600
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
 ROOT_URLCONF = 'project.urls'
 

--- a/srcs/requirements/user_management/project/project/settings.py
+++ b/srcs/requirements/user_management/project/project/settings.py
@@ -87,7 +87,7 @@ JWT_REFRESH_EXPIRATION_DELTA = datetime.timedelta(days=14)
 JWT_AUTH_COOKIE = True
 # Mark cookie containing access token as secure
 JWT_COOKIE_SECURE = True
-JWT_COOKIE_SAMESITE = 'Lax'
+JWT_COOKIE_SAMESITE = 'Strict'
 JWT_ALGORITHM = 'RS256'
 JWT_AUTH_HEADER_PREFIX = 'Token'
 JWT_ROTATE_REFRESH_TOKENS = True

--- a/srcs/requirements/user_management/project/project/settings.py
+++ b/srcs/requirements/user_management/project/project/settings.py
@@ -79,15 +79,17 @@ REST_FRAMWORK = {
 	)
 }
 
+
+#jwt token is realated on session, so when browser closed, session
 JWT_EXPIRATION_DELTA = datetime.timedelta(minutes=15)
 JWT_REFRESH_EXPIRATION_DELTA = datetime.timedelta(days=14)
 # Store access token in a cookie
-# JWT_AUTH_COOKIE = True
+JWT_AUTH_COOKIE = True
 # Mark cookie containing access token as secure
-# JWT_COOKIE_SECURE = True
-# JWT_COOKIE_SAMESITE = 'Lax'
-# JWT_ALGORITHM = 'RS256'
-# JWT_AUTH_HEADER_PREFIX = 'Token'
+JWT_COOKIE_SECURE = True
+JWT_COOKIE_SAMESITE = 'Lax'
+JWT_ALGORITHM = 'RS256'
+JWT_AUTH_HEADER_PREFIX = 'Token'
 JWT_ROTATE_REFRESH_TOKENS = True
 JWT_BLACKLIST_AFTER_ROTATION = True
 

--- a/srcs/requirements/user_management/project/project/settings.py
+++ b/srcs/requirements/user_management/project/project/settings.py
@@ -81,7 +81,7 @@ REST_FRAMWORK = {
 
 
 #jwt token is realated on session, so when browser closed, session
-JWT_EXPIRATION_DELTA = datetime.timedelta(minutes=15)
+JWT_EXPIRATION_DELTA = datetime.timedelta(minutes=1)
 JWT_REFRESH_EXPIRATION_DELTA = datetime.timedelta(days=14)
 # Store access token in a cookie
 JWT_AUTH_COOKIE = True


### PR DESCRIPTION
when user Authenticated on api_login_view, 
- generate Access Token with 'username' and Refresh Token(preparing refreshToken from the beginning for better UX and less server load) *for now accessToken lifetime is around 3-4 minutes, refreshtoken has 14 days
- Access Token on response header[Authorization], Refresh Token on request cookie
- from front-end, extract accessToken and store in memory. Storing the token in-memory means that you put this access token in a variable in your front-end site (like const accessToken = xyz). This means that the access token will be gone if the user switches tabs or refreshes the site.
- when user calls API, front-end calls API point /check_refresh, this request is including accessToken on its header[Authorization]
- check_refresh() : check accessToken expiration, if it expired check refreshToken expiration and regenerate accessToken with 'username' and put it on the response header as before. (-> front-end need to catch and update accessToken)

Storing Token on 'localStorage' : convenient but vulnerable to XSS attacks
Storing Token on Cookie : vulnerable to CSRF attacks but can be mitigated using sameSite flag and HTTPOnly
for additional security, generate both token together and only refreshToken is sotred on cookie, so accessToken on header is safe unless attacked by XSS.

ref: [https://angularindepth.com/posts/1382/localstorage-vs-cookies](url)