### PR TITLE
SNS verifications

### DIFF
--- a/srcs/requirements/user_management/project/account/templates/smsTest.html
+++ b/srcs/requirements/user_management/project/account/templates/smsTest.html
@@ -69,7 +69,7 @@
         phoneNumber = phoneNumber.slice(0, 3) + phoneNumber.slice(4);
         $.ajax({
             type: 'POST',
-            url: '{% url "account:sendCodeSMS" %}',
+            url: '{% url "account:updateSandbox" %}',
             data: {phone_number: phoneNumber},
             headers: { "X-CSRFToken": getCookie('csrftoken') },
             success: function(data) {
@@ -85,9 +85,9 @@
         var oneTimeCode = $('input[name="one_time_code"]').val();
         console.log('submitOneTimeCode submit');
         $.ajax({
-            url: '{% url "account:verify_one_time_code" %}',
+            url: '{% url "account:verifySandBox" %}',
             type: 'POST',
-            data: { 'one_time_code': oneTimeCode, 'context': context },
+            data: {phone_number: phoneNumber, otp: oneTimeCod },
             headers: { "X-CSRFToken": getCookie('csrftoken') },
             success: function (data) {
                 console.log('One-time code verification successful:', data);

--- a/srcs/requirements/user_management/project/account/views.py
+++ b/srcs/requirements/user_management/project/account/views.py
@@ -962,10 +962,10 @@ def update_sandbox(request, phone_number=None):
 # @login_required
 @ensure_csrf_cookie
 @csrf_protect
-# @require_POST
-@authentication_classes([])
-@permission_classes([AllowAny])
-def verify_sandBox(request, otp=None, phone_number=None):
+@api_view(['POST'])
+@authentication_classes([CustomJWTAuthentication])
+@permission_classes([IsAuthenticated])
+def verify_sandBox(request, phone_number=None, otp=None):
     print("\n--Verify SandBox\n")
     if request.method == 'POST':
         if phone_number is None:


### PR DESCRIPTION
make sure the phone number data is start with **+33 and rest of number without 0 in the first place**
tested with sms Test button(smsTest.html)

when user try to add or update phone number on profile.
    >  POST 'api/user_management/auth/updateSandbox' with body data {phone_number}
it will send otp to verify number for sandbox,
then call endpoint with phone number and one-time-password generated by sandbox
    > POST 'api/user_management/auth/verifySandBox' with body data {phone_number, otp}

and then submit form with other profile data, it will updated('profile_update')

if user set 2fa method as Sms, it will send otp with sms from login backend